### PR TITLE
Fix "metadata property 'VALUE_LIST' does not exist" log entries

### DIFF
--- a/regascripts/polling.fn
+++ b/regascripts/polling.fn
@@ -26,7 +26,6 @@ foreach (sSysVarId, dom.GetObject(ID_SYSTEM_VARIABLES).EnumUsedIDs()) {
   sValue = oSysVar.Value();
   iValueType = oSysVar.ValueType();
   iValueSubType = oSysVar.ValueSubType();
-  sValueList = oSysVar.ValueList();
 
   Write('"' # sSysVarId # '":[');
   if (iValueType == 20) {
@@ -40,6 +39,7 @@ foreach (sSysVarId, dom.GetObject(ID_SYSTEM_VARIABLES).EnumUsedIDs()) {
       string sItem;
       integer iIndex = 0;
       string sIndex = "null";
+      sValueList = oSysVar.ValueList();
       foreach(sItem, sValueList.Split(";")) {
         if ((sIndex == "null") && (sItem == sValue)) {
           sIndex = iIndex.ToString();


### PR DESCRIPTION
ReGaHss logs are regularly flooded by a block of "ReGaHss: Info: metadata property 'VALUE_LIST' does not exist [GetValueListProperty():iseDOMdp.cpp:425]" messages.
Although not fatal, they fill up the logs unnecessarily.

Requesting the oSysVar.ValueList() only if we are sure the property exists fixes this behaviour.