### PR TITLE
require node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,6 @@
 {
   "name": "iobroker.hm-rega",
   "version": "3.0.47",
-  "engines": {
-    "node": ">=10.0.0"
-  },
   "description": "Connects HomeMatic CCU \"Logic Layer\" (\"ReGaHSS\") to ioBroker",
   "author": "hobbyquaker <hq@ccu.io>",
   "contributors": [
@@ -23,6 +20,9 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/ioBroker/ioBroker.hm-rega"
+  },
+  "engines": {
+    "node": ">=16.0.0"
   },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.3",


### PR DESCRIPTION
adapter-core 3.x.x is known to fail during install when used with node 14 as npm 6 does not install peerDependencies. So this adapter requires node 16 or higher