### PR TITLE
In rooms.fn: Prüfen, ob Objekt vom Typ CHANNEL ist

### DIFF
--- a/regascripts/rooms.fn
+++ b/regascripts/rooms.fn
@@ -8,6 +8,7 @@
 object  oRoom;
 string  sRoomId;
 string  sChannelId;
+object  oChannel;
 boolean bFirst       = true;
 boolean bFirstSecond = true;
 
@@ -29,14 +30,18 @@ foreach (sRoomId, dom.GetObject(ID_ROOMS).EnumUsedIDs())
     Write('", "Channels":[');
 	bFirstSecond = true;
     foreach(sChannelId, oRoom.EnumIDs()) {
+        oChannel = dom.GetObject(sChannelId);
+        ! Objekt ueberspringen, falls nicht vom Typ CHANNEL (33)
+        if (oChannel.Type() != 33) { continue; }
+        
 		if (bFirstSecond == false) {
 		  Write(',');
 		} else {
 		  bFirstSecond = false;
 		}
-        string sIfaceId = dom.GetObject(sChannelId).Interface();
+        string sIfaceId = oChannel.Interface();
         string sIface = dom.GetObject(sIfaceId).Name();
-        Write('{"Address":"' # dom.GetObject(sChannelId).Address() # '",');
+        Write('{"Address":"' # oChannel.Address() # '",');
         Write('"Interface":"' # sIface # '"}');
 
     }


### PR DESCRIPTION
Bei mir gibt es folgendes Problem: Die Ausführung des Scripts rooms.fn wird bei der Auflistung der `Channels` eines Raums abgebrochen, sodass eine unvollständige Antwort (mit fehlerhafter JSON-Syntax) erzeugt wird.

Bei der Fehlersuche bin ich darauf gestoßen, dass `dom.GetObject(sChannelId)` nicht immer ein Objekt vom Typ `CHANNEL` zurückgibt, sondern in meinem Fall auch ein Objekt vom Typ `SINGLECONDITION`. In diesem Fall schlägt die Anweisung `dom.GetObject(sChannelId).Interface()` fehl und das Script bricht ab. Ich habe das Script darum um eine Überprüfung des Objekt-Typs erweitert.