### PR TITLE
In functions.fn: Prüfen, ob Objekt vom Typ CHANNEL ist

### DIFF
--- a/regascripts/functions.fn
+++ b/regascripts/functions.fn
@@ -8,6 +8,7 @@
 object  oFunction;
 string  sFunctionId;
 string  sChannelId;
+object  oChannel;
 boolean bFirst       = true;
 boolean bFirstSecond = true;
 
@@ -28,14 +29,18 @@ foreach (sFunctionId, dom.GetObject(ID_FUNCTIONS).EnumUsedIDs()) {
     Write('", "Channels": [');
 	bFirstSecond = true;
     foreach(sChannelId, oFunction.EnumUsedIDs()) {
+        oChannel = dom.GetObject(sChannelId);
+        ! Objekt ueberspringen, falls nicht vom Typ CHANNEL (33)
+        if (oChannel.Type() != 33) { continue; }
+        
 		if (bFirstSecond == false) {
 		  Write(',');
 		} else {
 		  bFirstSecond = false;
 		}
-        string sIfaceId = dom.GetObject(sChannelId).Interface();
+        string sIfaceId = oChannel.Interface();
         string sIface = dom.GetObject(sIfaceId).Name();
-        Write('{"Address":"' # dom.GetObject(sChannelId).Address() # '",');
+        Write('{"Address":"' # oChannel.Address() # '",');
         Write('"Interface":"' # sIface # '"}');
     }
     Write(']}');


### PR DESCRIPTION
Analog zu #441:

Bei mir gibt es folgendes Problem: Die Ausführung des Scripts functions.fn wird bei der Auflistung der Channels einer Funktion abgebrochen, sodass eine unvollständige Antwort (mit fehlerhafter JSON-Syntax) erzeugt wird.

Bei der Fehlersuche bin ich darauf gestoßen, dass dom.GetObject(sChannelId) nicht immer ein Objekt vom Typ CHANNEL zurückgibt, sondern in meinem Fall auch ein Objekt vom Typ SINGLECONDITION. In diesem Fall schlägt die Anweisung dom.GetObject(sChannelId).Interface() fehl und das Script bricht ab. Ich habe das Script darum um eine Überprüfung des Objekt-Typs erweitert.

Darf man davon ausgehen, dass Objekte vom Typ `CHANNEL` immer die Type-Nummer 33 haben? Andernfalls könnte man die Bedingung auch so formulieren: `oChannel.TypeName() != "CHANNEL"`.